### PR TITLE
Correct Frame.copy and Frame.copyProps doc blocks

### DIFF
--- a/src/lib/frame.ts
+++ b/src/lib/frame.ts
@@ -991,9 +991,10 @@ export class Frame implements Disposable, NativeWrapper<NativeFrame> {
   }
 
   /**
-   * Copy frame properties without copying data.
+   * Copy non-layout frame properties without copying data.
    *
-   * Copies metadata, timestamps, format info, etc. but not the actual data.
+   * Copies metadata like timestamp, duration, etc., but not the actual data.
+   * Layout-defining properties, such as width, height, channel count, format, etc., are not copied.
    * Useful for preparing output frames with same properties.
    *
    * Direct mapping to av_frame_copy_props().
@@ -1009,19 +1010,19 @@ export class Frame implements Disposable, NativeWrapper<NativeFrame> {
    *
    * const ret = dstFrame.copyProps(srcFrame);
    * FFmpegError.throwIfError(ret, 'copyProps');
-   * // dstFrame now has same properties as srcFrame
+   * // dstFrame now has same non-layout properties as srcFrame
    * ```
    *
-   * @see {@link copy} To copy both properties and data
+   * @see {@link copy} To copy data
    */
   copyProps(src: Frame): number {
     return this.native.copyProps(src.getNative());
   }
 
   /**
-   * Copy frame data and properties.
+   * Copy frame data.
    *
-   * Copies both data and metadata from source frame.
+   * Copies only data (but not metadata) from source frame.
    * Destination must have allocated buffers of correct size.
    *
    * Direct mapping to av_frame_copy().
@@ -1045,7 +1046,7 @@ export class Frame implements Disposable, NativeWrapper<NativeFrame> {
    * FFmpegError.throwIfError(ret, 'copy');
    * ```
    *
-   * @see {@link copyProps} To copy only properties
+   * @see {@link copyProps} To copy non-format metadata
    * @see {@link clone} To create new frame with copy
    */
   copy(src: Frame): number {


### PR DESCRIPTION
Hi, thank you so much for creating this library. It is put together exceptionally well and I love how you make full use of modern JavaScript features. It enabled me to build [webcodecs-polyfill](https://github.com/Vanilagy/webcodecs-polyfill)! <3

---

A great part of this lib is the extensive docs which, at least for me, made it possible to use large chunks of this library without prior knowledge of the FFmpeg C API. However, I did notice misleading (incorrect) documentation for the `copy` and `copyProps` methods on `Frame`.

The behavior of `copy`, from the FFmpeg docs:
> Copy the frame data from src to dst.
> This function does not allocate anything, dst must be already initialized and allocated with the same parameters as src.
> This function only copies the frame data (i.e. the contents of the data / extended data arrays), not any other properties.

And `copyProps`:
> Copy only "metadata" fields from src to dst.
> Metadata for the purpose of this function are those fields that do not affect the data layout in the buffers. E.g. pts, sample rate (for audio) or sample aspect ratio (for video), but not width/height or channel layout. Side data is also copied.

Source: https://www.ffmpeg.org/doxygen/4.3/group__lavu__frame.html

However, the existing docs in this library made it seem like `copy` copies everything (data + props), and `copyProps` only the props.

This is not true; `copy` *only* copies the data, and `copyProps` *only* copies the props, but not even all of them, at that. Layout-defining properties, such and width and height, are not copied - only "metadata" is copied.