### PR TITLE
Fix SharedTexture.mapTo passing DRM_PRIME wrapper as swFormat

### DIFF
--- a/src/api/utilities/electron-shared-texture.ts
+++ b/src/api/utilities/electron-shared-texture.ts
@@ -472,7 +472,7 @@ export class SharedTexture implements Disposable {
       const ctx = new HardwareFramesContext();
       ctx.alloc(targetHw.deviceContext);
       ctx.format = targetHw.devicePixelFormat;
-      ctx.swFormat = srcFrame.format as AVPixelFormat; // Use source format
+      ctx.swFormat = this._swFormat;
       ctx.width = srcFrame.width;
       ctx.height = srcFrame.height;
 


### PR DESCRIPTION
Found this while trying to pass DMA-BUF frames into VAAPI for encoding.

In my case I import a DMA-BUF with importHandle, then call mapTo() onto a VAAPI context for h264_vaapi. That currently fails with:

```text 
Failed to initialize mapping HardwareFramesContext: Invalid argument 
Unsupported format: drm_prime 
```

I think the issue is in ensureMappingContext:

```ts 
ctx.swFormat = srcFrame.format; 
```

For DMA-BUF imports, srcFrame.format is AV_PIX_FMT_DRM_PRIME, so FFmpeg rejects it as the software format for the mapping context. Using the texture’s own software format fixes it for me:

```ts 
ctx.swFormat = this._swFormat; 
```

Tiny repro on Intel UHD P630 / iHD, node-av@6.0.0-beta.5:

```ts 
const hw = HardwareContext.create(AV_HWDEVICE_TYPE_VAAPI, "/dev/dri/renderD128"); 
const st = SharedTexture.create(hw, { swFormat: AV_PIX_FMT_BGRA });  
const f = new Frame(); 
f.alloc(); f.width = 1920; 
f.height = 1080; 
f.format = AV_PIX_FMT_DRM_PRIME;  
st.mapTo(f, hw); // Unsupported format: drm_prime 
```

I wasn’t totally sure whether you’d want _swFormat used always here, or only when the source is AV_PIX_FMT_DRM_PRIME.

I also noticed _swFormat may not get updated when passing a per-call pixelFormat to importHandle on the DMA-BUF path, but maybe that’s separate.

I haven’t run the full suite locally, but verified this with the repro above against the beta.5 prebuilt.