### PR TITLE
feat(encoder): add preserveFramePictType to allow forced keyframes

### DIFF
--- a/src/api/encoder.ts
+++ b/src/api/encoder.ts
@@ -279,6 +279,26 @@ export interface EncoderOptions<C = unknown> {
   autoFormat?: boolean;
 
   /**
+   * Keep each frame's `pictType` instead of clearing it before encoding.
+   *
+   * By default the encoder resets `frame.pictType` to `AV_PICTURE_TYPE_NONE`,
+   * because when re-encoding a decoded stream the input frames carry frame-type
+   * hints that should not drive the output GOP structure. That clearing also
+   * discards a deliberately requested keyframe: setting
+   * `frame.pictType = AV_PICTURE_TYPE_I` (with `forced-idr` on encoders that
+   * support it) is the standard FFmpeg way to force an IDR for a specific frame,
+   * and it never reaches the codec.
+   *
+   * Set this to `true` to honour that request — required for on-demand keyframes
+   * in live streaming (packet-loss recovery, a late-joining viewer, a resized
+   * encode), where a receiver stays black until its first IDR. Leave it `false`
+   * for transcoding, where the input's frame types should be ignored.
+   *
+   * @default false
+   */
+  preserveFramePictType?: boolean;
+
+  /**
    * Additional codec-specific options.
    *
    * Key-value pairs of FFmpeg private codec options, passed directly to the encoder.
@@ -2659,9 +2679,12 @@ export class Encoder implements Disposable {
    * @internal
    */
   private prepareFrameForEncoding(frame: Frame): void {
-    // Clear pict_type - encoder will determine frame types based on its own settings
-    // Input stream's frame type hints are irrelevant when re-encoding
-    frame.pictType = AV_PICTURE_TYPE_NONE;
+    // Clear pict_type - encoder will determine frame types based on its own settings.
+    // Input stream's frame type hints are irrelevant when re-encoding. Opt out with
+    // { preserveFramePictType: true } to force keyframes via frame.pictType = I.
+    if (!this.options.preserveFramePictType) {
+      frame.pictType = AV_PICTURE_TYPE_NONE;
+    }
 
     // Adjust frame PTS and timebase to encoder timebase
     // This matches FFmpeg's adjust_frame_pts_to_encoder_tb() behavior which:

--- a/test/encoder.test.ts
+++ b/test/encoder.test.ts
@@ -6,6 +6,7 @@ import {
   AV_CHANNEL_LAYOUT_STEREO,
   AV_CHANNEL_ORDER_UNSPEC,
   AV_NOPTS_VALUE,
+  AV_PICTURE_TYPE_I,
   AV_PIX_FMT_RGB24,
   AV_PIX_FMT_YUV420P,
   AV_PIX_FMT_YUV422P,
@@ -250,6 +251,77 @@ describe('Encoder', () => {
       }
 
       encoder.close();
+    });
+
+    // Encode `count` gradient frames through `encoder`, requesting a forced
+    // keyframe on frame `forceAt` via pictType = I, and return the indices of
+    // the output packets that came out as keyframes.
+    async function keyframeIndices(encoder: Encoder, count: number, forceAt: number): Promise<number[]> {
+      const keyframes: number[] = [];
+      let outIdx = 0;
+      const drain = async (frame: Frame | null): Promise<void> => {
+        for await (using pkt of encodeFrame(encoder, frame)) {
+          if (pkt.isKeyframe) keyframes.push(outIdx);
+          outIdx++;
+        }
+      };
+      for (let i = 0; i < count; i++) {
+        using frame = new Frame();
+        frame.alloc();
+        frame.width = 320;
+        frame.height = 240;
+        frame.format = AV_PIX_FMT_YUV420P;
+        frame.pts = BigInt(i);
+        frame.timeBase = new Rational(1, 30);
+        assert.equal(frame.getBuffer(), 0, 'Should allocate frame buffer');
+        const planes = frame.data;
+        if (planes?.[0]) {
+          const y = planes[0];
+          for (let p = 0; p < 320 * 240; p++) y[p] = (p + i) % 256;
+          if (planes[1] && planes[2]) {
+            const chromaSize = (320 * 240) / 4;
+            for (let p = 0; p < chromaSize; p++) {
+              planes[1][p] = 128;
+              planes[2][p] = 128;
+            }
+          }
+        }
+        if (i === forceAt) frame.pictType = AV_PICTURE_TYPE_I;
+        await drain(frame);
+      }
+      await drain(null); // flush
+      return keyframes;
+    }
+
+    // A long GOP means the only keyframes are the initial IDR and any forced
+    // one, so the forced keyframe is unambiguous.
+    const forcedKeyframeEncoder = () =>
+      Encoder.create(FF_ENCODER_LIBX264, {
+        timeBase: new Rational(1, 30),
+        gopSize: 1000,
+        maxBFrames: 0,
+        options: { preset: 'ultrafast', tune: 'zerolatency', 'forced-idr': 1 },
+      });
+
+    it('does not force a keyframe from pictType by default', async () => {
+      const encoder = await forcedKeyframeEncoder();
+      const keyframes = await keyframeIndices(encoder, 10, 5);
+      encoder.close();
+      // Only the initial IDR; the request on frame 5 is cleared before encoding.
+      assert.deepEqual(keyframes, [0], `expected only the initial keyframe, got [${keyframes}]`);
+    });
+
+    it('forces a keyframe from pictType when preserveFramePictType is set', async () => {
+      const encoder = await Encoder.create(FF_ENCODER_LIBX264, {
+        timeBase: new Rational(1, 30),
+        gopSize: 1000,
+        maxBFrames: 0,
+        preserveFramePictType: true,
+        options: { preset: 'ultrafast', tune: 'zerolatency', 'forced-idr': 1 },
+      });
+      const keyframes = await keyframeIndices(encoder, 10, 5);
+      encoder.close();
+      assert.ok(keyframes.includes(5), `expected a forced keyframe at frame 5, got [${keyframes}]`);
     });
 
     it('should encode video frames (sync)', () => {


### PR DESCRIPTION
Fixes #314.

## Problem

The high-level `Encoder` clears `frame.pictType` on every frame in `prepareFrameForEncoding`:

```ts
// Clear pict_type - encoder will determine frame types based on its own settings
// Input stream's frame type hints are irrelevant when re-encoding
frame.pictType = AV_PICTURE_TYPE_NONE;
```

That makes it impossible to force a keyframe on demand. Setting `frame.pictType = AV_PICTURE_TYPE_I` (with `forced-idr` on encoders that support it) is the standard FFmpeg way to request an IDR for a specific frame, but it is erased before `avcodec_send_frame`, so the encoder never emits the forced keyframe.

For live streaming this matters: a decoder produces nothing before its first keyframe, and on a lossy or late-joining connection the client needs to request a fresh IDR (packet-loss recovery, a new viewer, a resized encode). Through the high-level API there was no way to honour that.

## Change

Clearing `pictType` is still correct for transcoding, where decoded input frames carry frame-type hints that should not drive the output GOP. So this is an **opt-in** option rather than a default change:

```ts
if (!this.options.preserveFramePictType) {
  frame.pictType = AV_PICTURE_TYPE_NONE;
}
```

- New `EncoderOptions.preserveFramePictType?: boolean` (default `false`).
- When `false` (default), behaviour is unchanged.
- When `true`, the frame's `pictType` is passed through, so `AV_PICTURE_TYPE_I` forces an IDR.

## Verification

Tested against libx264 with a long GOP (so the only keyframes are the initial IDR and any forced one), encoding 10 frames and requesting a forced keyframe on frame 5:

| | forced keyframe at frame 5 |
|---|---|
| default (no flag) | not present — unchanged behaviour |
| `preserveFramePictType: true` | present |

Both cases are covered by new tests in `test/encoder.test.ts`. Confirmed non-vacuous: reverting the guard makes the "forces a keyframe" test fail while the default-behaviour test still passes.

Happy to adjust — e.g. a dedicated `encoder.requestKeyframe()`-style API instead of a flag — if you'd prefer a different shape.
