### PR TITLE
fix: release large muxer write buffers to the OS

### DIFF
--- a/src/bindings/io_context.cc
+++ b/src/bindings/io_context.cc
@@ -1,9 +1,100 @@
 #include "io_context.h"
 #include <libavutil/error.h>
 #include <libavutil/mem.h>
-#include <future>
+#include <cstdint>
 #include <cstring>
+#include <future>
 #include <thread>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#else
+#include <sys/mman.h>
+#ifndef MAP_ANONYMOUS
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+#endif
+
+namespace {
+
+// Large, short-lived muxer writes can create severe process-heap retention
+// under sustained fMP4 workloads. Page-backed storage bypasses that heap and is
+// returned to the OS by the external Buffer finalizer.
+constexpr size_t kPageBackedWriteThreshold = 64 * 1024;
+
+uint8_t* AllocatePageBackedBuffer(size_t length) {
+#ifdef _WIN32
+  void* allocation = VirtualAlloc(nullptr, length, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+#else
+  void* allocation = mmap(nullptr, length, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (allocation == MAP_FAILED) {
+    allocation = nullptr;
+  }
+#endif
+
+  if (!allocation) {
+    return nullptr;
+  }
+
+  return static_cast<uint8_t*>(allocation);
+}
+
+void FreePageBackedBuffer(uint8_t* data, size_t length) {
+#ifdef _WIN32
+  VirtualFree(data, 0, MEM_RELEASE);
+#else
+  munmap(data, length);
+#endif
+}
+
+void FinalizePageBackedBuffer(napi_env env, void* data, void* hint) {
+  const size_t length = static_cast<size_t>(reinterpret_cast<uintptr_t>(hint));
+  Napi::MemoryManagement::AdjustExternalMemory(env, -static_cast<int64_t>(length));
+  FreePageBackedBuffer(static_cast<uint8_t*>(data), length);
+}
+
+Napi::Buffer<uint8_t> CopyWriteBuffer(Napi::Env env, const uint8_t* source, size_t length) {
+  if (length < kPageBackedWriteThreshold) {
+    return Napi::Buffer<uint8_t>::Copy(env, source, length);
+  }
+
+  uint8_t* data = AllocatePageBackedBuffer(length);
+  if (!data) {
+    // Allocation failure must not turn a recoverable write into an I/O error.
+    return Napi::Buffer<uint8_t>::Copy(env, source, length);
+  }
+
+  memcpy(data, source, length);
+
+  napi_value value;
+  void* const finalize_hint = reinterpret_cast<void*>(static_cast<uintptr_t>(length));
+  const napi_status status =
+    napi_create_external_buffer(env, length, data, FinalizePageBackedBuffer, finalize_hint, &value);
+
+  if (status == napi_ok) {
+    // Ownership transfers to Node only after the external Buffer exists.
+    Napi::MemoryManagement::AdjustExternalMemory(env, static_cast<int64_t>(length));
+    return Napi::Buffer<uint8_t>(env, value);
+  }
+
+  if (status == napi_no_external_buffers_allowed) {
+    // Some embedders disallow external buffers. Preserve compatibility by
+    // copying there, then release the temporary mapping exactly once even if
+    // Buffer::Copy leaves an empty value and a pending JavaScript exception.
+    Napi::Buffer<uint8_t> buffer = Napi::Buffer<uint8_t>::Copy(env, data, length);
+    FreePageBackedBuffer(data, length);
+    return buffer;
+  }
+
+  // Node never accepted ownership on any other failure.
+  FreePageBackedBuffer(data, length);
+  return Napi::Buffer<uint8_t>();
+}
+
+} // namespace
 
 namespace ffmpeg {
 
@@ -195,7 +286,10 @@ int IOContext::WritePacket(void* opaque, const uint8_t* buf, int buf_size) {
       Napi::Env env(data->env);
       Napi::HandleScope scope(env);
 
-      Napi::Buffer<uint8_t> buffer = Napi::Buffer<uint8_t>::Copy(env, const_cast<uint8_t*>(buf), buf_size);
+      Napi::Buffer<uint8_t> buffer = CopyWriteBuffer(env, buf, static_cast<size_t>(buf_size));
+      if (buffer.IsEmpty()) {
+        return AVERROR(EIO);
+      }
       Napi::Value result = data->write_callback_direct.Call({buffer});
 
       if (result.IsNumber()) {
@@ -218,7 +312,11 @@ int IOContext::WritePacket(void* opaque, const uint8_t* buf, int buf_size) {
 
   auto callback = [promisePtr, buf, buf_size](Napi::Env env, Napi::Function jsCallback) {
     try {
-      Napi::Buffer<uint8_t> buffer = Napi::Buffer<uint8_t>::Copy(env, const_cast<uint8_t*>(buf), buf_size);
+      Napi::Buffer<uint8_t> buffer = CopyWriteBuffer(env, buf, static_cast<size_t>(buf_size));
+      if (buffer.IsEmpty()) {
+        promisePtr->set_value(AVERROR(EIO));
+        return;
+      }
       Napi::Value result = jsCallback.Call({buffer});
 
       // Check if result is a Promise (has .then method)

--- a/test/io-context.test.ts
+++ b/test/io-context.test.ts
@@ -1422,6 +1422,40 @@ describe('IOContext', () => {
       io.freeContext();
     });
 
+    it('keeps large direct-callback write buffers valid after the native write returns', () => {
+      const retained: Buffer[] = [];
+      const io = new IOContext();
+      io.allocContextWithCallbacks(128 * 1024, 1, undefined, (buffer: Buffer) => {
+        retained.push(buffer);
+        return buffer.length;
+      });
+
+      const payload = Buffer.alloc(512 * 1024, 0x5a);
+      io.writeSync(payload);
+      io.flushSync();
+      io.freeContext();
+
+      assert.ok(retained.some((buffer) => buffer.length >= 64 * 1024), 'test must exercise the page-backed path');
+      assert.ok(Buffer.concat(retained).equals(payload), 'retained callback buffers must preserve the complete payload');
+    });
+
+    it('keeps large thread-safe-callback write buffers valid after the native write returns', async () => {
+      const retained: Buffer[] = [];
+      const io = new IOContext();
+      io.allocContextWithCallbacks(128 * 1024, 1, undefined, (buffer: Buffer) => {
+        retained.push(buffer);
+        return buffer.length;
+      });
+
+      const payload = Buffer.alloc(512 * 1024, 0xa5);
+      await io.write(payload);
+      await io.flush();
+      io.freeContext();
+
+      assert.ok(retained.some((buffer) => buffer.length >= 64 * 1024), 'test must exercise the page-backed path');
+      assert.ok(Buffer.concat(retained).equals(payload), 'retained callback buffers must preserve the complete payload');
+    });
+
     it('should support combined async read and seek callbacks', async () => {
       const fileBuffer = await readFile(testVideoFile);
       let position = 0;


### PR DESCRIPTION
## Summary

Sustained fMP4 muxing with large, variably sized writes can create severe process-heap retention under real long-lived camera workloads. This pull request moves large transient `IOContext::WritePacket()` callback buffers out of the regular process heap while preserving their copy and lifetime semantics.

Fixes #328

## Allocation path

`IOContext::WritePacket()` currently copies every FFmpeg write through `Napi::Buffer<uint8_t>::Copy()`. The affected production workload uses four permanent HKSV prebuffers, 4-second fragments, the default 2 MiB AVIO buffer, and high-resolution H.264 remux input. The resulting large, variably sized writes repeatedly churn the Node/libc heap.

## Changes

- Keep the existing regular Node-buffer path for writes below 64 KiB.
- Allocate larger transient write buffers with page-backed storage (`mmap` on POSIX, `VirtualAlloc` on Windows).
- Preserve page alignment by passing the allocation length through `finalize_hint` instead of storing a header in the mapping.
- Report the mapping to V8 with `Napi::MemoryManagement::AdjustExternalMemory()` and subtract it in the finalizer.
- Release the mapping from the external-buffer finalizer.
- Preserve a safe copy fallback for embedders that disallow external buffers and for allocation failure.
- Handle external-buffer creation failures without leaks or double frees.
- Add direct and thread-safe callback regression tests proving that retained large buffers remain valid after the native write returns.

FFmpeg data is still copied before the callback returns, so the patch does not introduce a zero-copy lifetime hazard.

The previously included `FMP4Stream.emitBoxGroup()` view optimization has been removed from this PR. It is independent and changes observable backing-buffer/`byteOffset` semantics.

## Production evidence

Affected deployment:

- Ubuntu 24.04.4 x86_64, glibc 2.39
- Node.js 24.18.0
- `fragDuration: 4_000_000`
- default `bufferSize: 2 * 1024 * 1024`
- no production `MALLOC_*` tunables

A run started on August 19, 2026 at 18:36 CEST. Proxmox RRD data shows the container below 1 GiB around 19:30, approximately 1.6 GiB at 20:00, 5.2 GiB at 20:30, 9.4 GiB at 21:00, and at its 10 GiB cgroup limit by 21:30. At 00:16 CEST the HomeKit process alone held 9,360,352 KiB of anonymous/private-dirty RSS. The cgroup had more than 53 million `memory.high` events and no OOM kill. A preceding run had reached the same limit before restart.

This does not show the 300 MiB warm-up plateau seen in the single-stream Debian/glibc-2.36 reproduction. Short isolated tests against the same real camera source, without HomeKit/HAP queues, also showed lower post-GC growth with `MALLOC_MMAP_THRESHOLD_=65536` or a low trim threshold.

## Verification

The revised head `76016bb` has been verified with:

- `npm run build:tests`
- `npm run build:tsc`
- `npm run lint`
- `npm run lint:gyp`
- `git diff --check`
- a complete native Linux x64 addon build and link on Ubuntu 24.04 / glibc 2.39 / Node.js 24.19.0, using the project Jellyfin FFmpeg build inputs and `prebuildify --napi --strip --arch=x64 --tag-libc`
- focused tests against that freshly built addon proving that retained large direct-callback and thread-safe-callback buffers remain valid after the native write returns

The GitHub workflow for this fork PR still requires maintainer approval before its jobs can start.
