### PR TITLE
fix: await stopped pipelines before teardown

### DIFF
--- a/src/api/fmp4-stream.ts
+++ b/src/api/fmp4-stream.ts
@@ -1143,14 +1143,19 @@ export class FMP4Stream {
       // Stop pipeline if running and wait for completion. Swallow a rejected
       // completion - the error is already surfaced via the onClose(error) path;
       // we just need cleanup to proceed.
-      if (this.pipeline && !this.pipeline.isStopped()) {
-        this.pipeline.stop();
+      const pipeline = this.pipeline;
+      if (pipeline) {
+        if (!pipeline.isStopped()) {
+          pipeline.stop();
+        }
         try {
-          await this.pipeline.completion;
+          await pipeline.completion;
         } catch {
           // Pipeline errored - proceed with teardown regardless.
         }
-        this.pipeline = undefined;
+        if (this.pipeline === pipeline) {
+          this.pipeline = undefined;
+        }
       }
 
       // Close all resources. The output goes FIRST: its async write worker may

--- a/src/api/rtp-stream.ts
+++ b/src/api/rtp-stream.ts
@@ -1107,14 +1107,19 @@ export class RTPStream {
       // the source demuxer's read (frame-source pipelines unwind via iterator.return
       // instead). Swallow a rejected completion here - the error is already surfaced
       // to the caller via the onClose(error) path; we just need cleanup to proceed.
-      if (this.pipeline && !this.pipeline.isStopped()) {
-        this.pipeline.stop();
+      const pipeline = this.pipeline;
+      if (pipeline) {
+        if (!pipeline.isStopped()) {
+          pipeline.stop();
+        }
         try {
-          await this.pipeline.completion;
+          await pipeline.completion;
         } catch {
           // Pipeline errored - proceed with teardown regardless.
         }
-        this.pipeline = undefined;
+        if (this.pipeline === pipeline) {
+          this.pipeline = undefined;
+        }
       }
 
       // Close all resources

--- a/test/fmp4-stream.test.ts
+++ b/test/fmp4-stream.test.ts
@@ -16,6 +16,14 @@ interface FMP4StreamInternals {
   incompleteBoxBuffer: Buffer | null;
   pendingFragment: { raw: Buffer }[];
   endFragments: () => void;
+  pipeline?: {
+    isStopped(): boolean;
+    stop(): void;
+    completion: Promise<void>;
+  };
+  output?: {
+    close(): Promise<void>;
+  };
 }
 
 const internalsOf = (stream: FMP4Stream): FMP4StreamInternals => stream as unknown as FMP4StreamInternals;
@@ -349,6 +357,36 @@ describe('FMP4Stream', () => {
       });
       await stream.start();
       await Promise.all([stream.stop(), stream.stop(), stream.stop()]);
+    });
+
+    it('waits for an already-stopped pipeline before closing native resources', async () => {
+      const stream = FMP4Stream.create('unused', { boxMode: true });
+      const internals = internalsOf(stream);
+      let completePipeline!: () => void;
+      const completion = new Promise<void>((resolve) => {
+        completePipeline = resolve;
+      });
+      let outputClosed = false;
+
+      internals.pipeline = {
+        isStopped: () => true,
+        stop: () => assert.fail('an already-stopped pipeline must not be stopped twice'),
+        completion,
+      };
+      internals.output = {
+        close: async () => {
+          outputClosed = true;
+        },
+      };
+
+      const stopping = stream.stop();
+      await settle();
+      assert.equal(outputClosed, false, 'native output was closed while the pipeline was still unwinding');
+
+      completePipeline();
+      await stopping;
+      assert.equal(outputClosed, true, 'native output should close after pipeline completion');
+      assert.equal(internals.pipeline, undefined, 'completed pipeline reference should be cleared');
     });
   });
 

--- a/test/rtp-stream.test.ts
+++ b/test/rtp-stream.test.ts
@@ -339,5 +339,45 @@ describe('RTPStream', skipWerift, () => {
       await packet;
       await stream.stop();
     });
+
+    it('waits for an already-stopped pipeline before closing native resources', async () => {
+      const { RTPStream } = await import('../src/webrtc/index.js');
+      const stream = RTPStream.create(getInputFile('video.mp4'));
+      const internals = stream as unknown as {
+        pipeline?: {
+          isStopped(): boolean;
+          stop(): void;
+          completion: Promise<void>;
+        };
+        videoOutput?: {
+          close(): Promise<void>;
+        };
+      };
+      let completePipeline!: () => void;
+      const completion = new Promise<void>((resolve) => {
+        completePipeline = resolve;
+      });
+      let outputClosed = false;
+
+      internals.pipeline = {
+        isStopped: () => true,
+        stop: () => assert.fail('an already-stopped pipeline must not be stopped twice'),
+        completion,
+      };
+      internals.videoOutput = {
+        close: async () => {
+          outputClosed = true;
+        },
+      };
+
+      const stopping = stream.stop();
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.equal(outputClosed, false, 'native output was closed while the pipeline was still unwinding');
+
+      completePipeline();
+      await stopping;
+      assert.equal(outputClosed, true, 'native output should close after pipeline completion');
+      assert.equal(internals.pipeline, undefined, 'completed pipeline reference should be cleared');
+    });
   });
 });


### PR DESCRIPTION
## Summary

Ensure `FMP4Stream.stop()` and `RTPStream.stop()` always wait for an existing pipeline to finish unwinding before closing native FFmpeg resources.

Fixes #329

## Root cause

Both teardown paths awaited `pipeline.completion` only while `pipeline.isStopped()` was false. An AbortSignal can call `pipeline.stop()` first, leaving this state:

- the pipeline is marked stopped;
- asynchronous pipeline work has not completed yet;
- stream teardown skips the completion barrier;
- muxer/output, codecs, hardware context, and demuxer may be closed while the pipeline still references them;
- the stale pipeline reference remains assigned.

That creates a native-resource teardown race and can result in use-after-free-style allocator corruption or crashes.

## Changes

- Capture the current pipeline reference before teardown.
- Call `pipeline.stop()` only when stop has not already been requested.
- Always await the captured pipeline's `completion` promise.
- Continue swallowing a completion rejection because it is already reported through `onClose`.
- Clear the field only when it still points to the captured pipeline.
- Apply the same lifecycle rule to both FMP4 and RTP streams.

## Regression coverage

Each stream now has a deterministic test with an already-stopped pipeline whose completion promise remains unresolved. The tests verify that:

- `pipeline.stop()` is not called a second time;
- native output resources remain open while the pipeline is unwinding;
- teardown proceeds only after completion resolves;
- the completed pipeline reference is cleared.

## Verification

- Linux/glibc x64 focused run: 31/31 FMP4 and RTP tests passed.
- `npm run build:tsc`
- `npm run build:tests`
- `npm run lint`
- `npm run lint:gyp`
- `git diff --check`
